### PR TITLE
Support PHP 8 and update phpspec to 5.x || 7.x in composer.json

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -4,12 +4,12 @@
     "license": "MIT",
 
     "require": {
-        "php": "^7.0",
+        "php": "^7.0 || ^8.0",
         "psr/container": "^1.0"
     },
 
     "require-dev": {
-        "phpspec/phpspec": "^3.2"
+        "phpspec/phpspec": "^5 || ^7"
     },
 
     "autoload": {


### PR DESCRIPTION
Update `composer.json` to support PHP ^8.0 and update `phpspec/phpspec` dependecy constraint to be compatible with PHP versions range: `7.0` - `8.0`.

I've tested `phpspec` - both latest 5.x.x an 7.x.x work with the current test scripts.

Allowing `phpspec/phpspec` version `^5` is required for covering PHP 7.0, 7.1, 7.2, while the latest phpspec covers 7.3, 7.4 and 8.0